### PR TITLE
PgAccess null parameters

### DIFF
--- a/DBAccess/MsAccess.cs
+++ b/DBAccess/MsAccess.cs
@@ -97,7 +97,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             if (this.inTransaction)
             {

--- a/DBAccess/MySqlAccess.cs
+++ b/DBAccess/MySqlAccess.cs
@@ -95,7 +95,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             return cmd;
         }

--- a/DBAccess/PgAccess.cs
+++ b/DBAccess/PgAccess.cs
@@ -98,7 +98,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             if (this.inTransaction) {
                 cmd.Transaction = this.transaction;

--- a/DBAccess/SqlServerAccess.cs
+++ b/DBAccess/SqlServerAccess.cs
@@ -94,7 +94,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             if (this.inTransaction)
             {

--- a/DBAccess/SqlServerAccessODBC.cs
+++ b/DBAccess/SqlServerAccessODBC.cs
@@ -79,7 +79,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             if (this.inTransaction)
             {

--- a/DBAccess/SqliteAccess.cs
+++ b/DBAccess/SqliteAccess.cs
@@ -96,7 +96,7 @@ namespace DBAccess
             cmd.CommandType = CommandType.Text;
             foreach (var parameter in parameters)
             {
-                cmd.Parameters.AddWithValue(parameter.Key, parameter.Value);
+                cmd.Parameters.AddWithValue(parameter.Key, (parameter.Value) ?? DBNull.Value);
             }
             if (this.inTransaction)
             {


### PR DESCRIPTION
Esto sucede cuando se requiere hacer un "Select" escogiendo que campos se quiere retornar desde el diccionario. Y como no van setiados los valores, entonces da un error  "Parameter  must have its value set".

`Dictionary<string, object> parametros = new Dictionary<string, object>()`
` parametros.Add("id",this.id);`
`parametros.Add("usuario", this.usuario);`
`parametros.Add("clave", this.clave);`

`DataTable result = Program.connection.SqlQuery(sql, parametros);`
